### PR TITLE
Fix missing import in Streamlit app

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -4,6 +4,7 @@ import streamlit as st
 import pandas as pd
 import matplotlib.pyplot as plt
 import plotly.express as px
+import time
 from data.scrape import *
 import plotly.graph_objects as go
 from visualization.helpers import *


### PR DESCRIPTION
## Summary
- add missing `time` import

## Testing
- `python -m py_compile streamlit_app.py`
- `python -m py_compile data/scrape.py`
- `python -m py_compile visualization/helpers.py`


------
https://chatgpt.com/codex/tasks/task_e_688b0c3f14bc832a97d064f7330808e4