### PR TITLE
Add options volatility surface page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,5 @@
 
 3. In the Streamlit sidebar, open the **"GDP & FX Explorer"** page to visualize
    historical GDP data for any country and compare currency valuations between
-   major pairs.
+   major pairs. You can also explore the **"Options Volatility Surface"** page
+   to view a 3D surface of implied volatility across strikes and expirations.

--- a/pages/options_volatility_surface.py
+++ b/pages/options_volatility_surface.py
@@ -1,0 +1,58 @@
+import streamlit as st
+import pandas as pd
+import plotly.graph_objects as go
+import yfinance as yf
+
+st.set_page_config(
+    page_title="Options Volatility Surface",
+    page_icon="📊",
+    layout="wide"
+)
+
+st.title("📊 Options Volatility Surface")
+
+@st.cache_data
+def load_option_data(symbol: str, max_expirations: int = 4) -> pd.DataFrame:
+    ticker = yf.Ticker(symbol)
+    try:
+        expirations = ticker.options[:max_expirations]
+    except Exception:
+        return pd.DataFrame(columns=["strike", "impliedVolatility", "expiration"])
+    frames = []
+    for exp in expirations:
+        try:
+            chain = ticker.option_chain(exp)
+            calls = chain.calls[["strike", "impliedVolatility"]].copy()
+            calls["expiration"] = exp
+            frames.append(calls)
+        except Exception:
+            continue
+    if frames:
+        return pd.concat(frames, ignore_index=True)
+    return pd.DataFrame(columns=["strike", "impliedVolatility", "expiration"])
+
+symbol = st.text_input("Ticker", "AAPL").upper().strip()
+max_exp = st.slider("Number of Expirations", 1, 10, 4)
+
+if symbol:
+    data = load_option_data(symbol, max_exp)
+    if data.empty:
+        st.error("No options data available.")
+    else:
+        pivot = data.pivot_table(index="strike", columns="expiration", values="impliedVolatility")
+        pivot.sort_index(inplace=True)
+        x = [str(c) for c in pivot.columns]
+        y = pivot.index.values
+        z = pivot.values
+        fig = go.Figure(data=[go.Surface(x=x, y=y, z=z, colorscale="Viridis")])
+        fig.update_layout(
+            height=700,
+            scene=dict(
+                xaxis_title="Expiration",
+                yaxis_title="Strike",
+                zaxis_title="Implied Volatility"
+            ),
+            title=f"{symbol} Implied Volatility Surface"
+        )
+        st.plotly_chart(fig, use_container_width=True)
+        st.dataframe(data)


### PR DESCRIPTION
## Summary
- add Streamlit page to visualize options implied volatility surface
- document new page in README

## Testing
- `python -m py_compile pages/options_volatility_surface.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68941ff66514832ab06dc0ea5cf65b65